### PR TITLE
show warning only if container is not in ignore list

### DIFF
--- a/pyouroboros/dockerclient.py
+++ b/pyouroboros/dockerclient.py
@@ -198,7 +198,17 @@ class Container(BaseImageObject):
                             else:
                                 running_containers.append(container)
                     except IndexError:
-                        self.logger.error("%s has no tags.. you should clean it up! Ignoring.", container.id)
+                        # portainer_agent.xxxxxxxxxxx.yyyyyyyy
+                        checklist = [
+                            container.name, container.name.split('.')[0],
+                            container.id, container.short_id
+                        ]
+
+                        ignore = filter(lambda e: e in self.config.ignore, checklist)
+                        if ignore:
+                            continue
+
+                        self.logger.warn("%s has no tags.. you should clean it up! Ignoring.", container.id)
                         continue
 
         except DockerException:


### PR DESCRIPTION
I am running portainer/agent in a swarm which doesn't seem to have a tag and adding to ignore list would still print **Error 'has no tags'**. 
  
```
$ docker images --filter "reference=portainer/agent"
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
portainer/agent     <none>              6ee12db2dac5        3 weeks ago         70MB
```
   
Furthermore the container name is like portainer_agent.xxxxxxxxxxx.yyyyyyyy and xxx.yyy changes on each update.
   
To keep it simple I've just modified _running_filter()_ but I think a even better solution would be to add something like:
```            
            filters={'status': 'running'}
            if self.config.label_enable:
                filters['label'] = ['com.ouroboros.enable=true']

            for container in self.client.containers.list(filters=filters):
```
but that kind of contradicts  _running_filter()_ and is somewhat duplicate of  _monitor_filter()_
